### PR TITLE
Create component-based project dashboard layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,47 +1,467 @@
-.app {
-  margin: 0 auto;
-  padding: 2rem;
-  max-width: 640px;
-  text-align: center;
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #0f172a;
+  background-color: #f5f7fb;
+  --color-success: #34d399;
+  --color-warning: #fbbf24;
+  --color-danger: #f87171;
+  --color-info: #60a5fa;
 }
 
-.app__header {
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: #f5f7fb;
+}
+
+.dashboard {
+  min-height: 100vh;
+  padding: 2.5rem;
   display: flex;
   flex-direction: column;
+  gap: 2rem;
+}
+
+.dashboard-header {
+  display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 1rem;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
+.dashboard-header__title {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
 }
 
-.logo:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-.app__subtitle {
+.dashboard-header h1 {
   margin: 0;
-  color: #adb5bd;
+  font-size: 2rem;
+  font-weight: 700;
 }
 
-.app__main {
-  margin-top: 2rem;
+.dashboard-header select {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  background: #fff;
+  color: inherit;
+}
+
+.header-button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  transition: background 150ms ease-in-out, transform 150ms ease-in-out;
+}
+
+.header-button:hover {
+  background: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+.dashboard__layout {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.stats-card {
+  background: #fff;
+  border-radius: 20px;
+  padding: 1.25rem;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.stats-card__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  font-size: 1.5rem;
+  background: #eff4ff;
+}
+
+.stats-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.stats-card__title {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.stats-card__value {
+  margin: 0;
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.stats-card__subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+.stats-card--default .stats-card__icon {
+  background: rgba(99, 102, 241, 0.1);
+}
+
+.stats-card--success .stats-card__icon {
+  background: rgba(52, 211, 153, 0.15);
+}
+
+.stats-card--danger .stats-card__icon {
+  background: rgba(248, 113, 113, 0.15);
+}
+
+.stats-card--warning .stats-card__icon {
+  background: rgba(251, 191, 36, 0.15);
+}
+
+.stats-card--info .stats-card__icon {
+  background: rgba(96, 165, 250, 0.15);
+}
+
+.dashboard__content {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.dashboard__main-panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.panel {
+  background: #fff;
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.panel__header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.sprint-status {
+  display: flex;
+  gap: 2rem;
+}
+
+.sprint-status__chart {
+  width: 160px;
+  height: 160px;
+  position: relative;
+}
+
+.sprint-status__donut {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--color-success) 0deg 226.8deg,
+    var(--color-info) 226.8deg 270deg,
+    var(--color-warning) 270deg 360deg
+  );
+  display: grid;
+  place-items: center;
+}
+
+.sprint-status__donut-hole {
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: inset 0 0 8px rgba(15, 23, 42, 0.08);
+}
+
+.sprint-status__legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.legend-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 0.75rem;
+}
+
+.legend-label {
+  margin: 0;
+  font-weight: 600;
+}
+
+.legend-value {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.task-priority {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-end;
+}
+
+.task-priority__chart {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  align-items: end;
+  height: 220px;
+  padding: 0 0.5rem;
+}
+
+.task-priority__column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.task-priority__bars {
+  display: flex;
+  flex-direction: column;
+  width: 60%;
+  gap: 0.4rem;
+  justify-content: flex-end;
+}
+
+.task-priority__bar {
+  width: 100%;
+  border-radius: 999px;
+}
+
+.task-priority__label {
+  margin: 0;
+  font-weight: 600;
+}
+
+.task-priority__legend {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.team-progress {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.team-progress__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.team-progress__info {
+  display: flex;
+  justify-content: space-between;
   align-items: center;
 }
 
-.app__counter button {
-  font-size: 1.25rem;
+.team-progress__name {
+  margin: 0;
+  font-weight: 600;
 }
 
-@media (prefers-color-scheme: light) {
-  .app__subtitle {
-    color: #495057;
+.team-progress__value {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.team-progress__bar {
+  background: #f1f5f9;
+  border-radius: 999px;
+  height: 10px;
+  overflow: hidden;
+}
+
+.team-progress__fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #2563eb, #60a5fa);
+}
+
+.assistant-panel {
+  height: 100%;
+}
+
+.assistant-panel__title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.assistant-panel__badge {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  background: rgba(37, 99, 235, 0.1);
+  font-size: 1.5rem;
+}
+
+.assistant-panel__conversation {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.assistant-message,
+.user-message {
+  display: flex;
+}
+
+.assistant-message {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
+}
+
+.user-message {
+  justify-content: flex-end;
+}
+
+.assistant-message__meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.assistant-message__bubble {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: 16px;
+  color: #1e3a8a;
+}
+
+.user-message__bubble {
+  margin: 0;
+  align-self: flex-end;
+  padding: 0.9rem 1rem;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 16px 16px 4px 16px;
+}
+
+.assistant-panel__input {
+  margin-top: auto;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.assistant-panel__input input {
+  flex: 1;
+  border-radius: 999px;
+  border: 1px solid #e2e8f0;
+  padding: 0.8rem 1.2rem;
+  font-size: 0.95rem;
+}
+
+.assistant-panel__input button {
+  border-radius: 999px;
+  border: none;
+  padding: 0.8rem 1.5rem;
+  font-weight: 600;
+  background: #2563eb;
+  color: #fff;
+  cursor: pointer;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 1024px) {
+  .dashboard__content {
+    grid-template-columns: 1fr;
+  }
+
+  .assistant-panel {
+    order: -1;
+  }
+}
+
+@media (max-width: 768px) {
+  .dashboard {
+    padding: 1.5rem;
+  }
+
+  .dashboard-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dashboard-header__title {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .header-button {
+    width: 100%;
+    justify-content: center;
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,28 +1,36 @@
-import { useState } from 'react';
-import reactLogo from './assets/react.svg';
 import './App.css';
+import DashboardHeader from './components/DashboardHeader';
+import StatsCard from './components/StatsCard';
+import SprintStatus from './components/SprintStatus';
+import TaskPriorityOverview from './components/TaskPriorityOverview';
+import TeamProgress from './components/TeamProgress';
+import AssistantPanel from './components/AssistantPanel';
+
+const stats = [
+  { icon: '✅', title: 'Completed Today', value: 12, subtitle: 'Logged today', variant: 'success' },
+  { icon: '🔁', title: 'Updated Today', value: 8, subtitle: 'Tasks updated', variant: 'default' },
+  { icon: '🆕', title: 'Created Today', value: 5, subtitle: 'New tasks added', variant: 'info' },
+  { icon: '⚠️', title: 'Overdue', value: 3, subtitle: 'Needs attention', variant: 'danger' },
+];
 
 function App() {
-  const [count, setCount] = useState(0);
-
   return (
-    <div className="app">
-      <header className="app__header">
-        <img src={reactLogo} className="logo" alt="React logo" />
-        <h1>RAG Project Management</h1>
-        <p className="app__subtitle">
-          Kick-start your Retrieval Augmented Generation project management UI with React and Vite.
-        </p>
-      </header>
-
-      <main className="app__main">
-        <p>The counter below confirms that state management is working:</p>
-        <div className="app__counter">
-          <button type="button" onClick={() => setCount((value) => value + 1)}>
-            count is {count}
-          </button>
-        </div>
-        <p>Edit <code>src/App.jsx</code> and save to test hot module replacement.</p>
+    <div className="dashboard">
+      <DashboardHeader />
+      <main className="dashboard__layout">
+        <section className="stats-grid">
+          {stats.map((stat) => (
+            <StatsCard key={stat.title} {...stat} />
+          ))}
+        </section>
+        <section className="dashboard__content">
+          <div className="dashboard__main-panels">
+            <SprintStatus />
+            <TaskPriorityOverview />
+            <TeamProgress />
+          </div>
+          <AssistantPanel />
+        </section>
       </main>
     </div>
   );

--- a/src/components/AssistantPanel.jsx
+++ b/src/components/AssistantPanel.jsx
@@ -1,0 +1,37 @@
+const AssistantPanel = () => {
+  return (
+    <section className="panel assistant-panel">
+      <header className="panel__header">
+        <div className="assistant-panel__title">
+          <span className="assistant-panel__badge" aria-hidden="true">
+            🤖
+          </span>
+          <h2>AI Assistant</h2>
+        </div>
+      </header>
+      <div className="assistant-panel__conversation">
+        <div className="assistant-message">
+          <p className="assistant-message__meta">Hello! I'm here to help you with your project management tasks.</p>
+          <p className="assistant-message__bubble">
+            Hello! I'm here to help you with your project management tasks. Ask me anything about your sprint!
+          </p>
+        </div>
+        <div className="user-message">
+          <p className="user-message__bubble">Can you show me the status of our current sprint?</p>
+        </div>
+        <div className="assistant-message">
+          <p className="assistant-message__bubble">
+            Based on the current sprint, 63% of tasks are done, 12% in progress, and 25% still to do. The backlog is
+            slightly behind schedule.
+          </p>
+        </div>
+      </div>
+      <form className="assistant-panel__input" aria-label="Send a message to the AI assistant">
+        <input type="text" placeholder="Ask a question..." />
+        <button type="button">Send</button>
+      </form>
+    </section>
+  );
+};
+
+export default AssistantPanel;

--- a/src/components/DashboardHeader.jsx
+++ b/src/components/DashboardHeader.jsx
@@ -1,0 +1,24 @@
+const DashboardHeader = () => {
+  return (
+    <header className="dashboard-header">
+      <div className="dashboard-header__title">
+        <h1>Project Dashboard</h1>
+        <div className="dashboard-header__filters">
+          <label htmlFor="project-select" className="visually-hidden">
+            Select project
+          </label>
+          <select id="project-select" defaultValue="E-Commerce Platform">
+            <option>E-Commerce Platform</option>
+            <option>Mobile Banking</option>
+            <option>AI Assistant</option>
+          </select>
+        </div>
+      </div>
+      <button type="button" className="header-button">
+        <span aria-hidden="true">➕</span> New Task
+      </button>
+    </header>
+  );
+};
+
+export default DashboardHeader;

--- a/src/components/SprintStatus.jsx
+++ b/src/components/SprintStatus.jsx
@@ -1,0 +1,35 @@
+const SprintStatus = () => {
+  const segments = [
+    { label: 'Done', percentage: 63, color: 'var(--color-success)' },
+    { label: 'To-Do', percentage: 25, color: 'var(--color-warning)' },
+    { label: 'In Progress', percentage: 12, color: 'var(--color-info)' },
+  ];
+
+  return (
+    <section className="panel">
+      <header className="panel__header">
+        <h2>Sprint Task Status</h2>
+      </header>
+      <div className="sprint-status">
+        <div className="sprint-status__chart" aria-hidden="true">
+          <div className="sprint-status__donut">
+            <div className="sprint-status__donut-hole" />
+          </div>
+        </div>
+        <ul className="sprint-status__legend">
+          {segments.map((segment) => (
+            <li key={segment.label}>
+              <span className="legend-dot" style={{ backgroundColor: segment.color }} />
+              <div>
+                <p className="legend-label">{segment.label}</p>
+                <p className="legend-value">{segment.percentage}%</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default SprintStatus;

--- a/src/components/StatsCard.jsx
+++ b/src/components/StatsCard.jsx
@@ -1,0 +1,16 @@
+const StatsCard = ({ icon, title, value, subtitle, variant = 'default' }) => {
+  return (
+    <div className={`stats-card stats-card--${variant}`}>
+      <div className="stats-card__icon" aria-hidden="true">
+        {icon}
+      </div>
+      <div className="stats-card__content">
+        <p className="stats-card__title">{title}</p>
+        <p className="stats-card__value">{value}</p>
+        {subtitle && <p className="stats-card__subtitle">{subtitle}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default StatsCard;

--- a/src/components/TaskPriorityOverview.jsx
+++ b/src/components/TaskPriorityOverview.jsx
@@ -1,0 +1,59 @@
+const TaskPriorityOverview = () => {
+  const priorities = [
+    { label: 'High', counts: { done: 10, inProgress: 6, todo: 2 } },
+    { label: 'Medium', counts: { done: 8, inProgress: 9, todo: 4 } },
+    { label: 'Low', counts: { done: 6, inProgress: 5, todo: 7 } },
+  ];
+
+  return (
+    <section className="panel">
+      <header className="panel__header">
+        <h2>Task Priority Overview</h2>
+      </header>
+      <div className="task-priority">
+        <div className="task-priority__chart" role="img" aria-label="Task priority bar chart">
+          {priorities.map((priority) => {
+            const total = priority.counts.done + priority.counts.inProgress + priority.counts.todo;
+            const segments = [
+              { key: 'done', value: priority.counts.done, color: 'var(--color-success)' },
+              { key: 'inProgress', value: priority.counts.inProgress, color: 'var(--color-info)' },
+              { key: 'todo', value: priority.counts.todo, color: 'var(--color-warning)' },
+            ];
+
+            return (
+              <div key={priority.label} className="task-priority__column">
+                <div className="task-priority__bars">
+                  {segments.map((segment) => (
+                    <div
+                      key={segment.key}
+                      className={`task-priority__bar task-priority__bar--${segment.key}`}
+                      style={{ height: `${(segment.value / total) * 100}%`, backgroundColor: segment.color }}
+                    >
+                      <span className="visually-hidden">
+                        {segment.value} {segment.key} tasks
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                <p className="task-priority__label">{priority.label}</p>
+              </div>
+            );
+          })}
+        </div>
+        <div className="task-priority__legend">
+          <p>
+            <span className="legend-dot" style={{ backgroundColor: 'var(--color-success)' }} /> Done
+          </p>
+          <p>
+            <span className="legend-dot" style={{ backgroundColor: 'var(--color-info)' }} /> In Progress
+          </p>
+          <p>
+            <span className="legend-dot" style={{ backgroundColor: 'var(--color-warning)' }} /> To-Do
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default TaskPriorityOverview;

--- a/src/components/TeamProgress.jsx
+++ b/src/components/TeamProgress.jsx
@@ -1,0 +1,36 @@
+const teams = [
+  { name: 'Backend', points: 40, total: 50 },
+  { name: 'Frontend', points: 34, total: 40 },
+  { name: 'QA', points: 18, total: 25 },
+  { name: 'DevOps', points: 12, total: 20 },
+];
+
+const TeamProgress = () => {
+  return (
+    <section className="panel">
+      <header className="panel__header">
+        <h2>Team Progress</h2>
+      </header>
+      <ul className="team-progress">
+        {teams.map((team) => {
+          const completion = Math.round((team.points / team.total) * 100);
+          return (
+            <li key={team.name} className="team-progress__item">
+              <div className="team-progress__info">
+                <p className="team-progress__name">{team.name}</p>
+                <p className="team-progress__value">
+                  {team.points}/{team.total} SP
+                </p>
+              </div>
+              <div className="team-progress__bar">
+                <div className="team-progress__fill" style={{ width: `${completion}%` }} />
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+};
+
+export default TeamProgress;

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,4 @@
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -12,55 +6,25 @@
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: inherit;
 }
 
 a:hover {
-  color: #535bf2;
+  color: inherit;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
+  background-color: #f5f7fb;
 }
 
 #root {
   width: 100%;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-
-button:hover {
-  border-color: #646cff;
-}
-
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-
-  button {
-    background-color: #f9f9f9;
-  }
+button,
+input,
+select {
+  font: inherit;
 }


### PR DESCRIPTION
## Summary
- replace the starter counter page with a component-driven project dashboard layout
- add reusable components for stats, sprint status, task priority, team progress, and the AI assistant panels
- refresh global and page styles to match the dashboard design and responsive behavior

## Testing
- npm install *(fails: 403 Forbidden when downloading from npm registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3db66bf94832d95aec2d4b835dfa7