### PR TITLE
Fix CSS links in dashboard HTML

### DIFF
--- a/src/project_dashboard.html
+++ b/src/project_dashboard.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Project Dashboard</title>
-    <link rel="stylesheet" href="./src/css/index.css" />
-    <link rel="stylesheet" href="./src/css/project_dashboard.css" />
-    <link rel="stylesheet" href="./src/css/DashboardHeader.css" />
-    <link rel="stylesheet" href="./src/css/StatsCard.css" />
-    <link rel="stylesheet" href="./src/css/SprintStatus.css" />
-    <link rel="stylesheet" href="./src/css/TaskPriorityOverview.css" />
-    <link rel="stylesheet" href="./src/css/TeamProgress.css" />
-    <link rel="stylesheet" href="./src/css/AssistantPanel.css" />
+    <link rel="stylesheet" href="./css/index.css" />
+    <link rel="stylesheet" href="./css/project_dashboard.css" />
+    <link rel="stylesheet" href="./css/DashboardHeader.css" />
+    <link rel="stylesheet" href="./css/StatsCard.css" />
+    <link rel="stylesheet" href="./css/SprintStatus.css" />
+    <link rel="stylesheet" href="./css/TaskPriorityOverview.css" />
+    <link rel="stylesheet" href="./css/TeamProgress.css" />
+    <link rel="stylesheet" href="./css/AssistantPanel.css" />
   </head>
   <body>
     <div class="project-dashboard">


### PR DESCRIPTION
## Summary
- correct the dashboard HTML to reference CSS assets without the duplicate src/ prefix
- ensure the static dashboard page loads its styles without MIME type errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e49f5e7b68832db959b4f99340b5cc