### PR TITLE
Add API-driven dashboard data fetching and refresh control

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,7 +1,12 @@
 import type { FC } from 'react';
 import '../css/DashboardHeader.css';
 
-const DashboardHeader: FC = () => {
+export interface DashboardHeaderProps {
+  onRefresh: () => void;
+  isRefreshing?: boolean;
+}
+
+const DashboardHeader: FC<DashboardHeaderProps> = ({ onRefresh, isRefreshing = false }) => {
   return (
     <header className="dashboard-header">
       <div className="dashboard-header__title">
@@ -17,9 +22,25 @@ const DashboardHeader: FC = () => {
           </select>
         </div>
       </div>
-      <button type="button" className="header-button">
-        <span aria-hidden="true">➕</span> New Task
-      </button>
+      <div className="dashboard-header__actions">
+        <button
+          type="button"
+          className="header-icon-button"
+          onClick={onRefresh}
+          disabled={isRefreshing}
+          aria-label={isRefreshing ? 'Refreshing data' : 'Refresh dashboard data'}
+        >
+          <span
+            aria-hidden="true"
+            className={`header-icon-button__icon${isRefreshing ? ' header-icon-button__icon--spinning' : ''}`}
+          >
+            ⟳
+          </span>
+        </button>
+        <button type="button" className="header-button" disabled={isRefreshing}>
+          <span aria-hidden="true">➕</span> New Task
+        </button>
+      </div>
     </header>
   );
 };

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -1,33 +1,541 @@
+import { useCallback, useEffect, useState } from 'react';
 import DashboardHeader from './DashboardHeader';
 import AssistantPanel from './AssistantPanel';
-import SprintStatus from './SprintStatus';
+import SprintStatus, { type SprintSegment } from './SprintStatus';
 import StatsCard, { type StatsCardProps } from './StatsCard';
-import TaskPriorityOverview from './TaskPriorityOverview';
-import TeamProgress from './TeamProgress';
+import TaskPriorityOverview, { type Priority } from './TaskPriorityOverview';
+import TeamProgress, { type TeamProgressEntry } from './TeamProgress';
+import { API_ENDPOINTS } from '../config';
 import '../css/project_dashboard.css';
 
-const stats: StatsCardProps[] = [
+const fallbackStats: StatsCardProps[] = [
   { icon: '✅', title: 'Completed Today', value: 12, subtitle: 'Logged today', variant: 'success' },
   { icon: '🔁', title: 'Updated Today', value: 8, subtitle: 'Tasks updated' },
   { icon: '🆕', title: 'Created Today', value: 5, subtitle: 'New tasks added', variant: 'info' },
   { icon: '⚠️', title: 'Overdue', value: 3, subtitle: 'Needs attention', variant: 'danger' },
 ];
 
+const fallbackSprintSegments: SprintSegment[] = [
+  { label: 'Done', percentage: 63, color: 'var(--color-success)' },
+  { label: 'To-Do', percentage: 25, color: 'var(--color-warning)' },
+  { label: 'In Progress', percentage: 12, color: 'var(--color-info)' },
+];
+
+const fallbackPriorities: Priority[] = [
+  { label: 'High', counts: { done: 10, inProgress: 6, todo: 2 } },
+  { label: 'Medium', counts: { done: 8, inProgress: 9, todo: 4 } },
+  { label: 'Low', counts: { done: 6, inProgress: 5, todo: 7 } },
+];
+
+const fallbackTeams: TeamProgressEntry[] = [
+  { name: 'Backend', points: 40, total: 50 },
+  { name: 'Frontend', points: 34, total: 40 },
+  { name: 'QA', points: 18, total: 25 },
+  { name: 'DevOps', points: 12, total: 20 },
+];
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
+
+const toFiniteNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const toNonEmptyString = (value: unknown): string | null => {
+  if (typeof value === 'string' && value.trim() !== '') {
+    return value.trim();
+  }
+
+  return null;
+};
+
+const toNumericOrString = (value: unknown): number | string | null => {
+  const numeric = toFiniteNumber(value);
+  if (numeric !== null) {
+    return numeric;
+  }
+
+  const stringValue = toNonEmptyString(value);
+  if (stringValue !== null) {
+    return stringValue;
+  }
+
+  return null;
+};
+
+const isStatsVariant = (value: unknown): value is StatsCardProps['variant'] =>
+  value === 'default' || value === 'success' || value === 'info' || value === 'danger';
+
+const normaliseLabelCase = (value: string): string =>
+  value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+const clampPercentage = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(100, Math.round(value)));
+};
+
+const toSafeInteger = (value: number): number => Math.max(0, Math.round(value));
+
+const inferSprintColor = (label: string): string => {
+  const normalised = label.toLowerCase();
+  if (normalised.includes('done') || normalised.includes('complete')) {
+    return 'var(--color-success)';
+  }
+
+  if (normalised.includes('todo') || normalised.includes('backlog') || normalised.includes('pending')) {
+    return 'var(--color-warning)';
+  }
+
+  return 'var(--color-info)';
+};
+
+const parseTaskSummary = (data: unknown): StatsCardProps[] => {
+  if (Array.isArray(data)) {
+    const parsed = data
+      .map((item) => {
+        if (!isRecord(item)) {
+          return null;
+        }
+
+        const title = toNonEmptyString(item.title);
+        const value = toNumericOrString(item.value ?? item.count ?? item.total ?? item.amount);
+
+        if (!title || value === null) {
+          return null;
+        }
+
+        const subtitle = toNonEmptyString(item.subtitle) ?? undefined;
+        const variant = isStatsVariant(item.variant) ? item.variant : undefined;
+
+        return {
+          title,
+          value,
+          subtitle,
+          variant,
+          icon: item.icon ?? '📊',
+        } satisfies StatsCardProps;
+      })
+      .filter((item): item is StatsCardProps => item !== null);
+
+    return parsed;
+  }
+
+  if (isRecord(data)) {
+    const mappings: Array<{
+      keys: string[];
+      stat: StatsCardProps;
+    }> = [
+      {
+        keys: ['completedToday', 'completed_today', 'doneToday'],
+        stat: { icon: '✅', title: 'Completed Today', subtitle: 'Logged today', value: 0, variant: 'success' },
+      },
+      {
+        keys: ['updatedToday', 'updated_today'],
+        stat: { icon: '🔁', title: 'Updated Today', subtitle: 'Tasks updated', value: 0 },
+      },
+      {
+        keys: ['createdToday', 'created_today', 'newTasks'],
+        stat: { icon: '🆕', title: 'Created Today', subtitle: 'New tasks added', value: 0, variant: 'info' },
+      },
+      {
+        keys: ['overdue', 'overdueTasks'],
+        stat: { icon: '⚠️', title: 'Overdue', subtitle: 'Needs attention', value: 0, variant: 'danger' },
+      },
+    ];
+
+    return mappings
+      .map(({ keys, stat }) => {
+        const value = keys
+          .map((key) => toNumericOrString(data[key]))
+          .find((candidate) => candidate !== null);
+
+        if (value === null || value === undefined) {
+          return null;
+        }
+
+        return { ...stat, value } satisfies StatsCardProps;
+      })
+      .filter((item): item is StatsCardProps => item !== null);
+  }
+
+  return [];
+};
+
+const parseSprintSegmentsValue = (value: unknown): SprintSegment[] | undefined => {
+  if (Array.isArray(value)) {
+    const items = value
+      .map((item) => {
+        if (!isRecord(item)) {
+          return null;
+        }
+
+        const label = toNonEmptyString(item.label ?? item.name ?? item.status);
+        const percentage = toFiniteNumber(item.percentage ?? item.percent ?? item.value);
+        const count = toFiniteNumber(item.count ?? item.tasks ?? item.total);
+        const color = toNonEmptyString(item.color) ?? undefined;
+
+        if (!label || (percentage === null && count === null)) {
+          return null;
+        }
+
+        return {
+          label: normaliseLabelCase(label),
+          percentage,
+          count,
+          color: color ?? inferSprintColor(label),
+        };
+      })
+      .filter(
+        (item): item is { label: string; percentage: number | null; count: number | null; color: string } => item !== null,
+      );
+
+    if (items.length === 0) {
+      return undefined;
+    }
+
+    const hasPercentage = items.some((item) => item.percentage !== null);
+    const totalCount = hasPercentage ? 0 : items.reduce((sum, item) => sum + (item.count ?? 0), 0);
+
+    return items.map((item) => {
+      const computedPercentage =
+        item.percentage !== null
+          ? item.percentage
+          : totalCount > 0
+            ? (item.count ?? 0) / totalCount * 100
+            : 0;
+
+      return {
+        label: item.label,
+        percentage: clampPercentage(computedPercentage),
+        color: item.color,
+      } satisfies SprintSegment;
+    });
+  }
+
+  if (isRecord(value)) {
+    const statusMappings = [
+      { label: 'Done', keys: ['done', 'completed', 'complete'] },
+      { label: 'In Progress', keys: ['inProgress', 'in_progress', 'progress'] },
+      { label: 'To-Do', keys: ['todo', 'to_do', 'backlog', 'pending'] },
+    ] as const;
+
+    const counts = statusMappings
+      .map(({ label, keys }) => {
+        const amount = keys.map((key) => toFiniteNumber(value[key])).find((candidate) => candidate !== null);
+        if (amount === null || amount === undefined) {
+          return null;
+        }
+
+        return { label, count: amount };
+      })
+      .filter((item): item is { label: string; count: number } => item !== null);
+
+    if (counts.length === 0) {
+      return undefined;
+    }
+
+    const total = counts.reduce((sum, item) => sum + item.count, 0);
+
+    return counts.map((item) => ({
+      label: item.label,
+      percentage: total > 0 ? clampPercentage((item.count / total) * 100) : 0,
+      color: inferSprintColor(item.label),
+    }));
+  }
+
+  return undefined;
+};
+
+const parsePriorityValue = (value: unknown): Priority[] | undefined => {
+  if (Array.isArray(value)) {
+    const parsed = value
+      .map((item) => {
+        if (!isRecord(item)) {
+          return null;
+        }
+
+        const label = toNonEmptyString(item.label ?? item.priority);
+        const done = toFiniteNumber(item.done ?? item.completed);
+        const inProgress = toFiniteNumber(item.inProgress ?? item.in_progress ?? item.progress);
+        const todo = toFiniteNumber(item.todo ?? item.to_do ?? item.pending);
+
+        if (!label || (done === null && inProgress === null && todo === null)) {
+          return null;
+        }
+
+        return {
+          label: normaliseLabelCase(label),
+          counts: {
+            done: toSafeInteger(done ?? 0),
+            inProgress: toSafeInteger(inProgress ?? 0),
+            todo: toSafeInteger(todo ?? 0),
+          },
+        } satisfies Priority;
+      })
+      .filter((item): item is Priority => item !== null);
+
+    return parsed.length > 0 ? parsed : undefined;
+  }
+
+  if (isRecord(value)) {
+    const parsed: Priority[] = [];
+
+    for (const [rawLabel, nested] of Object.entries(value)) {
+      if (!isRecord(nested)) {
+        continue;
+      }
+
+      const done = toFiniteNumber(nested.done ?? nested.completed);
+      const inProgress = toFiniteNumber(nested.inProgress ?? nested.in_progress ?? nested.progress);
+      const todo = toFiniteNumber(nested.todo ?? nested.to_do ?? nested.pending);
+
+      if (done === null && inProgress === null && todo === null) {
+        continue;
+      }
+
+      parsed.push({
+        label: normaliseLabelCase(rawLabel),
+        counts: {
+          done: toSafeInteger(done ?? 0),
+          inProgress: toSafeInteger(inProgress ?? 0),
+          todo: toSafeInteger(todo ?? 0),
+        },
+      });
+    }
+
+    return parsed.length > 0 ? parsed : undefined;
+  }
+
+  return undefined;
+};
+
+const parseTeamProgressValue = (value: unknown): TeamProgressEntry[] | undefined => {
+  if (Array.isArray(value)) {
+    const parsed = value
+      .map((item) => {
+        if (!isRecord(item)) {
+          return null;
+        }
+
+        const name = toNonEmptyString(item.name ?? item.team);
+        const points = toFiniteNumber(item.points ?? item.completed ?? item.value ?? item.current);
+        const total = toFiniteNumber(item.total ?? item.capacity ?? item.goal);
+        const percentage = toFiniteNumber(item.percentage ?? item.percent ?? item.progress);
+
+        if (!name || (points === null && total === null && percentage === null)) {
+          return null;
+        }
+
+        let computedPoints = points;
+        let computedTotal = total;
+
+        if (computedPoints === null && computedTotal !== null && percentage !== null) {
+          computedPoints = (percentage / 100) * computedTotal;
+        } else if (computedTotal === null && computedPoints !== null && percentage !== null && percentage !== 0) {
+          computedTotal = (computedPoints / percentage) * 100;
+        } else if (computedPoints === null && computedTotal === null && percentage !== null) {
+          computedPoints = percentage;
+          computedTotal = 100;
+        }
+
+        if (computedPoints === null && computedTotal === null) {
+          return null;
+        }
+
+        const safePoints = toSafeInteger(computedPoints ?? 0);
+        const safeTotal = Math.max(safePoints, toSafeInteger(computedTotal ?? 100));
+
+        return {
+          name: normaliseLabelCase(name),
+          points: safePoints,
+          total: safeTotal,
+        } satisfies TeamProgressEntry;
+      })
+      .filter((item): item is TeamProgressEntry => item !== null);
+
+    return parsed.length > 0 ? parsed : undefined;
+  }
+
+  if (isRecord(value)) {
+    const parsed: TeamProgressEntry[] = [];
+
+    for (const [rawName, nested] of Object.entries(value)) {
+      if (!isRecord(nested)) {
+        continue;
+      }
+
+      const points = toFiniteNumber(nested.points ?? nested.completed ?? nested.value ?? nested.current);
+      const total = toFiniteNumber(nested.total ?? nested.capacity ?? nested.goal);
+      const percentage = toFiniteNumber(nested.percentage ?? nested.percent ?? nested.progress);
+
+      if (points === null && total === null && percentage === null) {
+        continue;
+      }
+
+      let computedPoints = points;
+      let computedTotal = total;
+
+      if (computedPoints === null && computedTotal !== null && percentage !== null) {
+        computedPoints = (percentage / 100) * computedTotal;
+      } else if (computedTotal === null && computedPoints !== null && percentage !== null && percentage !== 0) {
+        computedTotal = (computedPoints / percentage) * 100;
+      } else if (computedPoints === null && computedTotal === null && percentage !== null) {
+        computedPoints = percentage;
+        computedTotal = 100;
+      }
+
+      const safePoints = toSafeInteger(computedPoints ?? 0);
+      const safeTotal = Math.max(safePoints, toSafeInteger(computedTotal ?? 100));
+
+      parsed.push({
+        name: normaliseLabelCase(rawName),
+        points: safePoints,
+        total: safeTotal,
+      });
+    }
+
+    return parsed.length > 0 ? parsed : undefined;
+  }
+
+  return undefined;
+};
+
+const deepSearchForArray = <T,>(value: unknown, parser: (candidate: unknown) => T[] | undefined, depth = 0): T[] | undefined => {
+  if (depth > 3) {
+    return undefined;
+  }
+
+  const direct = parser(value);
+  if (direct && direct.length > 0) {
+    return direct;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const result = deepSearchForArray(item, parser, depth + 1);
+      if (result && result.length > 0) {
+        return result;
+      }
+    }
+  } else if (isRecord(value)) {
+    for (const nested of Object.values(value)) {
+      const result = deepSearchForArray(nested, parser, depth + 1);
+      if (result && result.length > 0) {
+        return result;
+      }
+    }
+  }
+
+  return undefined;
+};
+
 const ProjectDashboard = (): JSX.Element => {
+  const [summaryStats, setSummaryStats] = useState<StatsCardProps[]>(fallbackStats);
+  const [sprintSegments, setSprintSegments] = useState<SprintSegment[]>(fallbackSprintSegments);
+  const [priorityOverview, setPriorityOverview] = useState<Priority[]>(fallbackPriorities);
+  const [teamProgress, setTeamProgress] = useState<TeamProgressEntry[]>(fallbackTeams);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const loadTaskSummary = useCallback(async () => {
+    try {
+      const response = await fetch(API_ENDPOINTS.taskSummary, { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`Failed to load task summary: ${response.status}`);
+      }
+
+      const payload = await response.json();
+      const parsed = parseTaskSummary(payload);
+      if (parsed.length > 0) {
+        setSummaryStats(parsed);
+      }
+    } catch (error) {
+      console.error('Unable to fetch task summary', error);
+    }
+  }, []);
+
+  const loadSprintData = useCallback(async () => {
+    try {
+      const response = await fetch(API_ENDPOINTS.sprintTasks, { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`Failed to load sprint data: ${response.status}`);
+      }
+
+      const payload = await response.json();
+      const segments = deepSearchForArray(payload, parseSprintSegmentsValue);
+      if (segments && segments.length > 0) {
+        setSprintSegments(segments);
+      }
+
+      const priorities = deepSearchForArray(payload, parsePriorityValue);
+      if (priorities && priorities.length > 0) {
+        setPriorityOverview(priorities);
+      }
+
+      const teams = deepSearchForArray(payload, parseTeamProgressValue);
+      if (teams && teams.length > 0) {
+        setTeamProgress(teams);
+      }
+    } catch (error) {
+      console.error('Unable to fetch sprint data', error);
+    }
+  }, []);
+
+  const loadAllData = useCallback(async () => {
+    await Promise.all([loadTaskSummary(), loadSprintData()]);
+  }, [loadTaskSummary, loadSprintData]);
+
+  useEffect(() => {
+    void loadAllData();
+  }, [loadAllData]);
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    try {
+      const response = await fetch(API_ENDPOINTS.build, { method: 'POST' });
+      if (!response.ok) {
+        throw new Error(`Failed to trigger build: ${response.status}`);
+      }
+    } catch (error) {
+      console.error('Unable to trigger data rebuild', error);
+    }
+
+    try {
+      await loadAllData();
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [loadAllData]);
+
   return (
     <div className="project-dashboard">
-      <DashboardHeader />
+      <DashboardHeader onRefresh={handleRefresh} isRefreshing={isRefreshing} />
       <main className="project-dashboard__layout">
         <section className="project-dashboard__stats" aria-label="Project statistics summary">
-          {stats.map((stat) => (
+          {summaryStats.map((stat) => (
             <StatsCard key={stat.title} {...stat} />
           ))}
         </section>
         <section className="project-dashboard__content">
           <div className="project-dashboard__main">
-            <SprintStatus />
-            <TaskPriorityOverview />
-            <TeamProgress />
+            <SprintStatus segments={sprintSegments} />
+            <TaskPriorityOverview priorities={priorityOverview} />
+            <TeamProgress teams={teamProgress} />
           </div>
           <AssistantPanel />
         </section>

--- a/src/components/SprintStatus.tsx
+++ b/src/components/SprintStatus.tsx
@@ -1,19 +1,17 @@
 import type { FC } from 'react';
 import '../css/SprintStatus.css';
 
-type SprintSegment = {
+export type SprintSegment = {
   label: string;
   percentage: number;
   color: string;
 };
 
-const segments: SprintSegment[] = [
-  { label: 'Done', percentage: 63, color: 'var(--color-success)' },
-  { label: 'To-Do', percentage: 25, color: 'var(--color-warning)' },
-  { label: 'In Progress', percentage: 12, color: 'var(--color-info)' },
-];
+export interface SprintStatusProps {
+  segments: SprintSegment[];
+}
 
-const SprintStatus: FC = () => {
+const SprintStatus: FC<SprintStatusProps> = ({ segments }) => {
   return (
     <section className="panel">
       <header className="panel__header">

--- a/src/components/TaskPriorityOverview.tsx
+++ b/src/components/TaskPriorityOverview.tsx
@@ -1,20 +1,14 @@
 import type { FC } from 'react';
 import '../css/TaskPriorityOverview.css';
 
-type PriorityKey = 'done' | 'inProgress' | 'todo';
+export type PriorityKey = 'done' | 'inProgress' | 'todo';
 
-type PriorityCounts = Record<PriorityKey, number>;
+export type PriorityCounts = Record<PriorityKey, number>;
 
-type Priority = {
+export type Priority = {
   label: string;
   counts: PriorityCounts;
 };
-
-const priorities: Priority[] = [
-  { label: 'High', counts: { done: 10, inProgress: 6, todo: 2 } },
-  { label: 'Medium', counts: { done: 8, inProgress: 9, todo: 4 } },
-  { label: 'Low', counts: { done: 6, inProgress: 5, todo: 7 } },
-];
 
 const segmentColors: Record<PriorityKey, string> = {
   done: 'var(--color-success)',
@@ -22,7 +16,11 @@ const segmentColors: Record<PriorityKey, string> = {
   todo: 'var(--color-warning)',
 };
 
-const TaskPriorityOverview: FC = () => {
+export interface TaskPriorityOverviewProps {
+  priorities: Priority[];
+}
+
+const TaskPriorityOverview: FC<TaskPriorityOverviewProps> = ({ priorities }) => {
   return (
     <section className="panel">
       <header className="panel__header">
@@ -32,6 +30,8 @@ const TaskPriorityOverview: FC = () => {
         <div className="task-priority__chart" role="img" aria-label="Task priority bar chart">
           {priorities.map((priority) => {
             const total = priority.counts.done + priority.counts.inProgress + priority.counts.todo;
+            const hasWork = total > 0;
+            const denominator = hasWork ? total : 1;
             const segments = (Object.keys(priority.counts) as PriorityKey[]).map((key) => ({
               key,
               value: priority.counts[key],
@@ -45,7 +45,10 @@ const TaskPriorityOverview: FC = () => {
                     <div
                       key={segment.key}
                       className={`task-priority__bar task-priority__bar--${segment.key}`}
-                      style={{ height: `${(segment.value / total) * 100}%`, backgroundColor: segment.color }}
+                      style={{
+                        height: hasWork ? `${(segment.value / denominator) * 100}%` : '0%',
+                        backgroundColor: segment.color,
+                      }}
                     >
                       <span className="visually-hidden">
                         {segment.value} {segment.key} tasks

--- a/src/components/TeamProgress.tsx
+++ b/src/components/TeamProgress.tsx
@@ -1,20 +1,17 @@
 import type { FC } from 'react';
 import '../css/TeamProgress.css';
 
-type TeamProgressEntry = {
+export type TeamProgressEntry = {
   name: string;
   points: number;
   total: number;
 };
 
-const teams: TeamProgressEntry[] = [
-  { name: 'Backend', points: 40, total: 50 },
-  { name: 'Frontend', points: 34, total: 40 },
-  { name: 'QA', points: 18, total: 25 },
-  { name: 'DevOps', points: 12, total: 20 },
-];
+export interface TeamProgressProps {
+  teams: TeamProgressEntry[];
+}
 
-const TeamProgress: FC = () => {
+const TeamProgress: FC<TeamProgressProps> = ({ teams }) => {
   return (
     <section className="panel">
       <header className="panel__header">
@@ -22,7 +19,7 @@ const TeamProgress: FC = () => {
       </header>
       <ul className="team-progress">
         {teams.map((team) => {
-          const completion = Math.round((team.points / team.total) * 100);
+          const completion = team.total > 0 ? Math.round((team.points / team.total) * 100) : 0;
           return (
             <li key={team.name} className="team-progress__item">
               <div className="team-progress__info">

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,17 @@
+const DEFAULT_API_SERVER = 'http://localhost:8000';
+
+const normaliseBaseUrl = (value: string): string => value.replace(/\/+$/, '');
+
+const resolvedFromEnv = typeof import.meta !== 'undefined' ? (import.meta.env?.VITE_API_SERVER as string | undefined) : undefined;
+
+const baseUrl = resolvedFromEnv && resolvedFromEnv.trim() !== '' ? resolvedFromEnv : DEFAULT_API_SERVER;
+
+export const API_SERVER = normaliseBaseUrl(baseUrl);
+
+export const API_ENDPOINTS = {
+  build: `${API_SERVER}/build`,
+  taskSummary: `${API_SERVER}/project-dashboard/task-summary`,
+  sprintTasks: `${API_SERVER}//project-dashboard/tasks-of-sprint?sprint=20`,
+} as const;
+
+export default API_SERVER;

--- a/src/css/DashboardHeader.css
+++ b/src/css/DashboardHeader.css
@@ -12,6 +12,12 @@
   gap: 1.5rem;
 }
 
+.dashboard-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .dashboard-header__filters {
   display: flex;
   align-items: center;
@@ -50,4 +56,62 @@
 .header-button:hover {
   background: #1d4ed8;
   transform: translateY(-1px);
+}
+
+.header-button:disabled {
+  background: #60a5fa;
+  cursor: not-allowed;
+  transform: none;
+  opacity: 0.85;
+}
+
+.header-icon-button {
+  border: none;
+  border-radius: 999px;
+  width: 2.75rem;
+  height: 2.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #e2e8f0;
+  color: #0f172a;
+  font-size: 1.2rem;
+  cursor: pointer;
+  transition: background 150ms ease-in-out, transform 150ms ease-in-out;
+}
+
+.header-icon-button:hover {
+  background: #cbd5f5;
+  transform: translateY(-1px);
+}
+
+.header-icon-button:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.45);
+  outline-offset: 2px;
+}
+
+.header-icon-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  transform: none;
+}
+
+.header-icon-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@keyframes dashboard-header-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.header-icon-button__icon--spinning {
+  animation: dashboard-header-spin 1.1s linear infinite;
 }


### PR DESCRIPTION
## Summary
- make the dashboard fetch summary, sprint, priority, and team data from the configured API endpoints
- add a refresh icon button in the header that triggers the build endpoint and reloads dashboard data while showing a spinner
- update dashboard panels to accept dynamic props, handle empty datasets safely, and introduce a configurable API server helper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e50eb9e52c832db8d34865c2ec39b4