### PR TITLE
Restore animations to dashboard visualizations

### DIFF
--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -527,8 +527,8 @@ const ProjectDashboard = (): JSX.Element => {
       <DashboardHeader onRefresh={handleRefresh} isRefreshing={isRefreshing} />
       <main className="project-dashboard__layout">
         <section className="project-dashboard__stats" aria-label="Project statistics summary">
-          {summaryStats.map((stat) => (
-            <StatsCard key={stat.title} {...stat} />
+          {summaryStats.map((stat, index) => (
+            <StatsCard key={stat.title} {...stat} animationOrder={index} />
           ))}
         </section>
         <section className="project-dashboard__content">

--- a/src/components/SprintStatus.tsx
+++ b/src/components/SprintStatus.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import { type CSSProperties, type FC, useEffect, useMemo, useState } from 'react';
 import '../css/SprintStatus.css';
 
 export type SprintSegment = {
@@ -12,6 +12,48 @@ export interface SprintStatusProps {
 }
 
 const SprintStatus: FC<SprintStatusProps> = ({ segments }) => {
+  const [isAnimated, setIsAnimated] = useState(false);
+
+  useEffect(() => {
+    setIsAnimated(false);
+    const frame = requestAnimationFrame(() => {
+      setIsAnimated(true);
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, [segments]);
+
+  const donutStyle = useMemo(() => {
+    if (segments.length === 0) {
+      return {
+        backgroundImage: 'conic-gradient(var(--color-info) 0deg 360deg)',
+      } satisfies CSSProperties;
+    }
+
+    const total = segments.reduce((sum, segment) => sum + Math.max(segment.percentage, 0), 0);
+    const denominator = total > 0 ? total : 1;
+
+    let cumulative = 0;
+    const style: (CSSProperties & Record<string, string | number>) = {};
+    const stops: string[] = [];
+
+    segments.forEach((segment, index) => {
+      const safeValue = Math.max(segment.percentage, 0);
+      const share = (safeValue / denominator) * 360;
+      const start = cumulative;
+      cumulative += share;
+      style[`--segment-${index}-start` as string] = `${start}deg`;
+      style[`--segment-${index}-end` as string] = `${cumulative}deg`;
+      style[`--segment-${index}-color` as string] = segment.color;
+      stops.push(`var(--segment-${index}-color) calc(var(--segment-${index}-start) * var(--progress)) calc(var(--segment-${index}-end) * var(--progress))`);
+    });
+
+    style.backgroundImage = `conic-gradient(${stops.join(', ')})`;
+    return style;
+  }, [segments]);
+
   return (
     <section className="panel">
       <header className="panel__header">
@@ -19,7 +61,10 @@ const SprintStatus: FC<SprintStatusProps> = ({ segments }) => {
       </header>
       <div className="sprint-status">
         <div className="sprint-status__chart" aria-hidden="true">
-          <div className="sprint-status__donut">
+          <div
+            className={`sprint-status__donut ${isAnimated ? 'is-animated' : ''}`}
+            style={donutStyle}
+          >
             <div className="sprint-status__donut-hole" />
           </div>
         </div>

--- a/src/components/StatsCard.tsx
+++ b/src/components/StatsCard.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode } from 'react';
+import { type CSSProperties, type FC, type ReactNode, useEffect, useState } from 'react';
 import '../css/StatsCard.css';
 
 export type StatsCardVariant = 'default' | 'success' | 'info' | 'danger';
@@ -9,11 +9,38 @@ export interface StatsCardProps {
   value: number | string;
   subtitle?: string;
   variant?: StatsCardVariant;
+  animationOrder?: number;
 }
 
-const StatsCard: FC<StatsCardProps> = ({ icon, title, value, subtitle, variant = 'default' }) => {
+const StatsCard: FC<StatsCardProps> = ({
+  icon,
+  title,
+  value,
+  subtitle,
+  variant = 'default',
+  animationOrder = 0,
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      setIsVisible(true);
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, []);
+
+  const cardStyle: CSSProperties & Record<string, string | number> = {
+    ['--enter-delay' as string]: `${Math.max(animationOrder, 0) * 0.08}s`,
+  };
+
   return (
-    <div className={`stats-card stats-card--${variant}`}>
+    <div
+      className={`stats-card stats-card--${variant} ${isVisible ? 'stats-card--visible' : ''}`}
+      style={cardStyle}
+    >
       <div className="stats-card__icon" aria-hidden="true">
         {icon}
       </div>

--- a/src/components/TeamProgress.tsx
+++ b/src/components/TeamProgress.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import { type FC, useEffect, useState } from 'react';
 import '../css/TeamProgress.css';
 
 export type TeamProgressEntry = {
@@ -12,6 +12,19 @@ export interface TeamProgressProps {
 }
 
 const TeamProgress: FC<TeamProgressProps> = ({ teams }) => {
+  const [isAnimated, setIsAnimated] = useState(false);
+
+  useEffect(() => {
+    setIsAnimated(false);
+    const frame = requestAnimationFrame(() => {
+      setIsAnimated(true);
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, [teams]);
+
   return (
     <section className="panel">
       <header className="panel__header">
@@ -29,7 +42,10 @@ const TeamProgress: FC<TeamProgressProps> = ({ teams }) => {
                 </p>
               </div>
               <div className="team-progress__bar">
-                <div className="team-progress__fill" style={{ width: `${completion}%` }} />
+                <div
+                  className="team-progress__fill"
+                  style={{ width: isAnimated ? `${completion}%` : '0%' }}
+                />
               </div>
             </li>
           );

--- a/src/css/SprintStatus.css
+++ b/src/css/SprintStatus.css
@@ -10,18 +10,26 @@
   position: relative;
 }
 
+@property --progress {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 0;
+}
+
 .sprint-status__donut {
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  background: conic-gradient(
-    var(--color-success) 0deg 226.8deg,
-    var(--color-warning) 226.8deg 316.8deg,
-    var(--color-info) 316.8deg 360deg
-  );
   display: flex;
   align-items: center;
   justify-content: center;
+  background: conic-gradient(var(--color-info) 0deg 360deg);
+  --progress: 0;
+  transition: --progress 1.2s ease-out;
+}
+
+.sprint-status__donut.is-animated {
+  --progress: 1;
 }
 
 .sprint-status__donut-hole {
@@ -58,4 +66,11 @@
   margin: 0;
   font-size: 0.85rem;
   color: #64748b;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sprint-status__donut {
+    transition: none;
+    --progress: 1;
+  }
 }

--- a/src/css/StatsCard.css
+++ b/src/css/StatsCard.css
@@ -6,6 +6,15 @@
   gap: 1rem;
   align-items: center;
   box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+  transition-delay: var(--enter-delay, 0s);
+}
+
+.stats-card--visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .stats-card__icon {
@@ -61,4 +70,12 @@
 
 .stats-card--info .stats-card__icon {
   background: rgba(96, 165, 250, 0.15);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stats-card {
+    transition: none;
+    opacity: 1;
+    transform: none;
+  }
 }

--- a/src/css/TaskPriorityOverview.css
+++ b/src/css/TaskPriorityOverview.css
@@ -35,6 +35,16 @@
   border-radius: 999px;
   position: relative;
   overflow: hidden;
+  height: 100%;
+  transform: scaleY(0);
+  transform-origin: bottom;
+  will-change: transform;
+  transition: transform 0.7s cubic-bezier(0.33, 1, 0.68, 1);
+  transition-delay: var(--bar-delay, 0s);
+}
+
+.task-priority__bar.is-animated {
+  transform: scaleY(var(--bar-fill, 0));
 }
 
 .task-priority__label {
@@ -55,4 +65,11 @@
   margin: 0;
   display: flex;
   align-items: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .task-priority__bar {
+    transition: none;
+    transform: scaleY(var(--bar-fill, 0));
+  }
 }

--- a/src/css/TeamProgress.css
+++ b/src/css/TeamProgress.css
@@ -44,4 +44,11 @@
   height: 100%;
   background: linear-gradient(90deg, #22c55e, #16a34a);
   border-radius: 999px;
+  transition: width 0.9s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .team-progress__fill {
+    transition: none;
+  }
 }


### PR DESCRIPTION
## Summary
- add staged entry animations to summary cards, donut chart, stacked bars, and team progress meter for the project dashboard
- drive animations with requestAnimationFrame-triggered CSS variables while respecting reduced motion preferences

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e51a7bd2fc832da5694837630ab92a