### PR TITLE
Connect dashboard stats and assistant to backend APIs

### DIFF
--- a/src/components/SprintStatus.tsx
+++ b/src/components/SprintStatus.tsx
@@ -5,6 +5,7 @@ export type SprintSegment = {
   label: string;
   percentage: number;
   color: string;
+  count?: number | null;
 };
 
 export interface SprintStatusProps {
@@ -17,6 +18,7 @@ type EnhancedSegment = SprintSegment & {
   dashLength: number;
   dashOffset: number;
   displayValue: number;
+  displayCount: number | null;
 };
 
 const RADIUS = 68;
@@ -42,11 +44,15 @@ const SprintStatus: FC<SprintStatusProps> = ({ segments }) => {
       const safeValue = Number.isFinite(segment.percentage)
         ? Math.max(segment.percentage, 0)
         : 0;
+      const rawCount = typeof segment.count === 'number' && Number.isFinite(segment.count)
+        ? Math.max(Math.round(segment.count), 0)
+        : null;
 
       return {
         ...segment,
         value: safeValue,
         displayValue: Math.round(safeValue),
+        displayCount: rawCount,
       } satisfies Omit<EnhancedSegment, 'ratio' | 'dashLength' | 'dashOffset'>;
     });
 
@@ -63,6 +69,7 @@ const SprintStatus: FC<SprintStatusProps> = ({ segments }) => {
           dashLength: CIRCUMFERENCE,
           dashOffset: 0,
           displayValue: 0,
+          displayCount: null,
         },
       ] satisfies EnhancedSegment[];
     }
@@ -80,6 +87,7 @@ const SprintStatus: FC<SprintStatusProps> = ({ segments }) => {
         ratio,
         dashLength,
         dashOffset,
+        displayCount: segment.displayCount ?? null,
       } satisfies EnhancedSegment;
     });
   }, [segments]);
@@ -157,6 +165,11 @@ const SprintStatus: FC<SprintStatusProps> = ({ segments }) => {
             {activeSegment ? (
               <>
                 <span className="sprint-status__center-value">{activeSegment.displayValue}%</span>
+                {activeSegment.displayCount !== null ? (
+                  <span className="sprint-status__center-count">
+                    {activeSegment.displayCount} task{activeSegment.displayCount === 1 ? '' : 's'}
+                  </span>
+                ) : null}
                 <span className="sprint-status__center-label">{activeSegment.label}</span>
               </>
             ) : (
@@ -180,7 +193,14 @@ const SprintStatus: FC<SprintStatusProps> = ({ segments }) => {
                 <span className="legend-dot" style={{ backgroundColor: segment.color }} />
                 <div>
                   <p className="legend-label">{segment.label}</p>
-                  <p className="legend-value">{segment.displayValue}%</p>
+                  <p className="legend-value">
+                    <span>{segment.displayValue}%</span>
+                    {segment.displayCount !== null ? (
+                      <span className="legend-count">
+                        {segment.displayCount} task{segment.displayCount === 1 ? '' : 's'}
+                      </span>
+                    ) : null}
+                  </p>
                 </div>
               </button>
             </li>

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ export const API_ENDPOINTS = {
   build: `${API_SERVER}/build`,
   taskSummary: `${API_SERVER}/project-dashboard/task-summary`,
   sprintTasks: `${API_SERVER}/project-dashboard/tasks-of-sprint?sprint=20`,
+  ask: `${API_SERVER}/ask`,
 } as const;
 
 export default API_SERVER;

--- a/src/css/AssistantPanel.css
+++ b/src/css/AssistantPanel.css
@@ -53,6 +53,61 @@
   line-height: 1.4;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.assistant-message__bubble--typing {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.typing-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 48px;
+}
+
+.typing-indicator__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #475569;
+  opacity: 0.3;
+  animation: typing-indicator-bounce 1s infinite ease-in-out;
+}
+
+.typing-indicator__dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.typing-indicator__dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes typing-indicator-bounce {
+  0%,
+  80%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.3;
+  }
+  40% {
+    transform: translateY(-4px);
+    opacity: 1;
+  }
+}
+
 .assistant-message__bubble {
   background: #e2e8f0;
   color: #1e293b;
@@ -99,4 +154,14 @@
 
 .assistant-panel__input button:hover {
   background: #1d4ed8;
+}
+
+.assistant-panel__input input:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.assistant-panel__input button:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
 }

--- a/src/css/SprintStatus.css
+++ b/src/css/SprintStatus.css
@@ -48,12 +48,19 @@
   color: #0f172a;
 }
 
+.sprint-status__center-count {
+  margin-top: 0.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
 .sprint-status__center-label {
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: #64748b;
-  margin-top: 0.2rem;
+  margin-top: 0.25rem;
 }
 
 .sprint-status__legend {
@@ -101,10 +108,19 @@
   margin: 0;
   font-size: 0.85rem;
   color: #64748b;
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  flex-wrap: wrap;
 }
 
 .sprint-status__legend-item.is-active .legend-value {
   color: #0f172a;
+}
+
+.legend-count {
+  color: inherit;
+  font-weight: 600;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- fetch project stats from the task summary endpoint with resilient parsing so the cards reflect API data
- surface sprint status task counts in the chart and legend for clearer hover feedback
- wire the assistant panel to the ask endpoint with a default prompt, loading state, and typing indicator animation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e526eafe80832d8a37874cca933923