### PR TITLE
Fetch dashboard stats from ask endpoint

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -52,9 +52,6 @@ const DashboardHeader: FC<DashboardHeaderProps> = ({
             ⟳
           </span>
         </button>
-        <button type="button" className="header-button" disabled={isRefreshing}>
-          <span aria-hidden="true">➕</span> New Task
-        </button>
       </div>
     </header>
   );

--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -479,6 +479,52 @@ const createEndpointForProject = (endpoint: string, project: string): string => 
   }
 };
 
+const extractAskPayload = (payload: unknown): unknown => {
+  if (payload === null || payload === undefined) {
+    return undefined;
+  }
+
+  if (typeof payload === 'string') {
+    const trimmed = payload.trim();
+    if (trimmed === '') {
+      return undefined;
+    }
+
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return trimmed;
+    }
+  }
+
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (isRecord(payload)) {
+    const candidates = ['answer', 'result', 'data', 'payload', 'message', 'output'];
+    for (const key of candidates) {
+      if (key in payload) {
+        const nested = extractAskPayload(payload[key]);
+        if (nested !== undefined) {
+          return nested;
+        }
+      }
+    }
+
+    return payload;
+  }
+
+  return undefined;
+};
+
+const buildTaskSummaryQuestion = (project: string): string =>
+  [
+    `Provide current task summary metrics for the project "${project}".`,
+    'Respond with JSON using either an array of objects (title, value, subtitle?, variant?, icon?)',
+    'or an object containing keys like completedToday, updatedToday, createdToday, overdue.',
+  ].join(' ');
+
 const ProjectDashboard = (): JSX.Element => {
   const [summaryStats, setSummaryStats] = useState<StatsCardProps[]>([]);
   const [sprintSegments, setSprintSegments] = useState<SprintSegment[]>([]);
@@ -489,15 +535,18 @@ const ProjectDashboard = (): JSX.Element => {
 
   const loadTaskSummary = useCallback(async (project: string) => {
     try {
-      const response = await fetch(createEndpointForProject(API_ENDPOINTS.taskSummary, project), {
-        cache: 'no-store',
+      const response = await fetch(API_ENDPOINTS.ask, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: buildTaskSummaryQuestion(project) }),
       });
       if (!response.ok) {
         throw new Error(`Failed to load task summary: ${response.status}`);
       }
 
       const payload = await response.json();
-      const parsed = parseTaskSummary(payload);
+      const answer = extractAskPayload(payload);
+      const parsed = parseTaskSummary(answer ?? payload);
       setSummaryStats(parsed.length > 0 ? parsed : fallbackStats);
     } catch (error) {
       console.error('Unable to fetch task summary', error);

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,6 @@ export const API_SERVER = normaliseBaseUrl(baseUrl);
 
 export const API_ENDPOINTS = {
   build: `${API_SERVER}/build`,
-  taskSummary: `${API_SERVER}/project-dashboard/task-summary`,
   sprintTasks: `${API_SERVER}/project-dashboard/tasks-of-sprint?sprint=20`,
   ask: `${API_SERVER}/ask`,
 } as const;


### PR DESCRIPTION
## Summary
- remove the New Task action from the dashboard header
- request project summary statistics through the ask endpoint with flexible response parsing
- drop the unused task summary endpoint configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e52cddeaec832db2f8f53e18015d4e