### PR TITLE
Fetch dashboard task summary from API

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ export const API_SERVER = normaliseBaseUrl(baseUrl);
 
 export const API_ENDPOINTS = {
   build: `${API_SERVER}/build`,
+  taskSummary: `${API_SERVER}/project-dashboard/task-summary`,
   sprintTasks: `${API_SERVER}/project-dashboard/tasks-of-sprint?sprint=20`,
   ask: `${API_SERVER}/ask`,
 } as const;


### PR DESCRIPTION
## Summary
- load project dashboard statistics from the task-summary REST endpoint instead of hardcoded values
- simplify dashboard logic by removing the ask-based parsing helpers and keeping fallback data as backup
- expose the new task summary endpoint in the shared API configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e52f9a6638832d98b8cfa5ceeb1e18