### PR TITLE
Use API data for sprint dashboard widgets

### DIFF
--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -15,25 +15,6 @@ const fallbackStats: StatsCardProps[] = [
   { icon: '⚠️', title: 'Overdue', value: 3, subtitle: 'Needs attention', variant: 'danger' },
 ];
 
-const fallbackSprintSegments: SprintSegment[] = [
-  { label: 'Done', percentage: 63, color: 'var(--color-success)', count: 63 },
-  { label: 'To-Do', percentage: 25, color: 'var(--color-warning)', count: 25 },
-  { label: 'In Progress', percentage: 12, color: 'var(--color-info)', count: 12 },
-];
-
-const fallbackPriorities: Priority[] = [
-  { label: 'High', counts: { done: 10, inProgress: 6, todo: 2 } },
-  { label: 'Medium', counts: { done: 8, inProgress: 9, todo: 4 } },
-  { label: 'Low', counts: { done: 6, inProgress: 5, todo: 7 } },
-];
-
-const fallbackTeams: TeamProgressEntry[] = [
-  { name: 'Backend', points: 40, total: 50 },
-  { name: 'Frontend', points: 34, total: 40 },
-  { name: 'QA', points: 18, total: 25 },
-  { name: 'DevOps', points: 12, total: 20 },
-];
-
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
 
 const toFiniteNumber = (value: unknown): number | null => {
@@ -516,18 +497,18 @@ const ProjectDashboard = (): JSX.Element => {
 
       const payload = await response.json();
       const segments = deepSearchForArray(payload, parseSprintSegmentsValue);
-      setSprintSegments(segments && segments.length > 0 ? segments : fallbackSprintSegments);
+      setSprintSegments(segments && segments.length > 0 ? segments : []);
 
       const priorities = deepSearchForArray(payload, parsePriorityValue);
-      setPriorityOverview(priorities && priorities.length > 0 ? priorities : fallbackPriorities);
+      setPriorityOverview(priorities && priorities.length > 0 ? priorities : []);
 
       const teams = deepSearchForArray(payload, parseTeamProgressValue);
-      setTeamProgress(teams && teams.length > 0 ? teams : fallbackTeams);
+      setTeamProgress(teams && teams.length > 0 ? teams : []);
     } catch (error) {
       console.error('Unable to fetch sprint data', error);
-      setSprintSegments(fallbackSprintSegments);
-      setPriorityOverview(fallbackPriorities);
-      setTeamProgress(fallbackTeams);
+      setSprintSegments([]);
+      setPriorityOverview([]);
+      setTeamProgress([]);
     }
   }, []);
 

--- a/src/components/TaskPriorityOverview.tsx
+++ b/src/components/TaskPriorityOverview.tsx
@@ -96,17 +96,20 @@ const TaskPriorityOverview: FC<TaskPriorityOverviewProps> = ({ priorities }) => 
     [handleColumnLeave],
   );
 
+  const hasPriorities = priorityAnimations.length > 0;
+
   return (
     <section className="panel">
       <header className="panel__header">
         <h2>Task Priority Overview</h2>
       </header>
-      <div className="task-priority">
-        <div className="task-priority__chart" role="img" aria-label="Task priority bar chart">
-          {priorityAnimations.map((priority) => {
-            const isColumnActive = hoveredTarget?.label === priority.label;
-            const activeSegment =
-              isColumnActive && hoveredTarget?.key !== 'all'
+      {hasPriorities ? (
+        <div className="task-priority">
+          <div className="task-priority__chart" role="img" aria-label="Task priority bar chart">
+            {priorityAnimations.map((priority) => {
+              const isColumnActive = hoveredTarget?.label === priority.label;
+              const activeSegment =
+                isColumnActive && hoveredTarget?.key !== 'all'
                 ? priority.segments.find((segment) => segment.key === hoveredTarget.key)
                 : undefined;
 
@@ -162,20 +165,23 @@ const TaskPriorityOverview: FC<TaskPriorityOverviewProps> = ({ priorities }) => 
                 <p className="task-priority__label">{priority.label}</p>
               </div>
             );
-          })}
+            })}
+          </div>
+          <div className="task-priority__legend">
+            <p>
+              <span className="legend-dot" style={{ backgroundColor: segmentColors.done }} /> Done
+            </p>
+            <p>
+              <span className="legend-dot" style={{ backgroundColor: segmentColors.inProgress }} /> In Progress
+            </p>
+            <p>
+              <span className="legend-dot" style={{ backgroundColor: segmentColors.todo }} /> To-Do
+            </p>
+          </div>
         </div>
-        <div className="task-priority__legend">
-          <p>
-            <span className="legend-dot" style={{ backgroundColor: segmentColors.done }} /> Done
-          </p>
-          <p>
-            <span className="legend-dot" style={{ backgroundColor: segmentColors.inProgress }} /> In Progress
-          </p>
-          <p>
-            <span className="legend-dot" style={{ backgroundColor: segmentColors.todo }} /> To-Do
-          </p>
-        </div>
-      </div>
+      ) : (
+        <p className="panel__empty">No priority data available.</p>
+      )}
     </section>
   );
 };

--- a/src/components/TeamProgress.tsx
+++ b/src/components/TeamProgress.tsx
@@ -25,32 +25,38 @@ const TeamProgress: FC<TeamProgressProps> = ({ teams }) => {
     };
   }, [teams]);
 
+  const hasTeams = teams.length > 0;
+
   return (
     <section className="panel">
       <header className="panel__header">
         <h2>Team Progress</h2>
       </header>
-      <ul className="team-progress">
-        {teams.map((team) => {
-          const completion = team.total > 0 ? Math.round((team.points / team.total) * 100) : 0;
-          return (
-            <li key={team.name} className="team-progress__item">
-              <div className="team-progress__info">
-                <p className="team-progress__name">{team.name}</p>
-                <p className="team-progress__value">
-                  {team.points}/{team.total} SP
-                </p>
-              </div>
-              <div className="team-progress__bar">
-                <div
-                  className="team-progress__fill"
-                  style={{ width: isAnimated ? `${completion}%` : '0%' }}
-                />
-              </div>
-            </li>
-          );
-        })}
-      </ul>
+      {hasTeams ? (
+        <ul className="team-progress">
+          {teams.map((team) => {
+            const completion = team.total > 0 ? Math.round((team.points / team.total) * 100) : 0;
+            return (
+              <li key={team.name} className="team-progress__item">
+                <div className="team-progress__info">
+                  <p className="team-progress__name">{team.name}</p>
+                  <p className="team-progress__value">
+                    {team.points}/{team.total} SP
+                  </p>
+                </div>
+                <div className="team-progress__bar">
+                  <div
+                    className="team-progress__fill"
+                    style={{ width: isAnimated ? `${completion}%` : '0%' }}
+                  />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <p className="panel__empty">No team progress data available.</p>
+      )}
     </section>
   );
 };

--- a/src/css/project_dashboard.css
+++ b/src/css/project_dashboard.css
@@ -54,6 +54,12 @@
   color: #0f172a;
 }
 
+.panel__empty {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
 .legend-dot {
   display: inline-block;
   width: 12px;


### PR DESCRIPTION
## Summary
- remove hard-coded sprint, priority and team datasets from the project dashboard
- rely on the sprint tasks API response when rendering sprint status, priority overview and team progress
- add empty-state messaging for widgets when the API does not return data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e531c1c7bc832d817cceb98301f126