### PR TITLE
Restyle project dashboard to reduce whitespace

### DIFF
--- a/src/css/DashboardHeader.css
+++ b/src/css/DashboardHeader.css
@@ -3,12 +3,12 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 1.5rem;
-  background: #ffffff;
-  border-radius: 24px;
-  padding: 1.75rem 2rem;
-  border: 1px solid rgba(226, 232, 240, 0.8);
-  box-shadow: 0 20px 38px rgba(15, 23, 42, 0.08);
+  gap: 1.2rem;
+  background: linear-gradient(160deg, #ffffff 0%, #f5f8ff 100%);
+  border-radius: 20px;
+  padding: 1.4rem 1.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.06);
 }
 
 .dashboard-header__title {
@@ -19,7 +19,7 @@
 
 .dashboard-header__title h1 {
   margin: 0;
-  font-size: 2rem;
+  font-size: 1.75rem;
   font-weight: 700;
   color: #0f172a;
 }
@@ -37,38 +37,38 @@
 }
 
 .dashboard-header select {
-  border: 1px solid rgba(226, 232, 240, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 12px;
-  padding: 0.6rem 1.15rem;
+  padding: 0.6rem 1rem;
   font-size: 0.95rem;
   background: #ffffff;
   color: #0f172a;
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.06);
 }
 
 .dashboard-header__actions {
   display: flex;
   align-items: center;
-  gap: 0.85rem;
+  gap: 0.75rem;
 }
 
 .header-icon-button {
   border: none;
-  border-radius: 16px;
-  width: 2.9rem;
-  height: 2.9rem;
+  border-radius: 14px;
+  width: 2.6rem;
+  height: 2.6rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: rgba(226, 232, 240, 0.8);
+  background: rgba(148, 163, 184, 0.18);
   color: #0f172a;
-  font-size: 1.2rem;
+  font-size: 1.15rem;
   cursor: pointer;
   transition: background 150ms ease-in-out, transform 150ms ease-in-out;
 }
 
 .header-icon-button:hover:not(:disabled) {
-  background: rgba(148, 163, 184, 0.3);
+  background: rgba(37, 99, 235, 0.12);
   transform: translateY(-1px);
 }
 
@@ -105,7 +105,7 @@
 
 @media (max-width: 768px) {
   .dashboard-header {
-    padding: 1.5rem;
+    padding: 1.25rem 1.4rem;
   }
 
   .dashboard-header__title {

--- a/src/css/StatsCard.css
+++ b/src/css/StatsCard.css
@@ -1,15 +1,15 @@
 .stats-card {
-  background: #ffffff;
-  border-radius: 20px;
-  padding: 1.5rem;
+  background: linear-gradient(160deg, #ffffff 0%, #f4f7ff 100%);
+  border-radius: 16px;
+  padding: 1.25rem 1.4rem;
   display: flex;
-  gap: 1.25rem;
+  gap: 1rem;
   align-items: center;
-  border: 1px solid rgba(226, 232, 240, 0.8);
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.07);
   opacity: 0;
-  transform: translateY(14px);
-  transition: opacity 0.6s ease, transform 0.6s ease;
+  transform: translateY(12px);
+  transition: opacity 0.45s ease, transform 0.45s ease;
   transition-delay: var(--enter-delay, 0s);
 }
 
@@ -19,12 +19,12 @@
 }
 
 .stats-card__icon {
-  width: 52px;
-  height: 52px;
-  border-radius: 16px;
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
   display: grid;
   place-items: center;
-  font-size: 1.55rem;
+  font-size: 1.35rem;
   background: rgba(37, 99, 235, 0.08);
   color: #2563eb;
 }
@@ -32,21 +32,21 @@
 .stats-card__content {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.2rem;
 }
 
 .stats-card__title {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 600;
   color: #64748b;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.05em;
 }
 
 .stats-card__value {
   margin: 0;
-  font-size: 2rem;
+  font-size: 1.75rem;
   font-weight: 700;
   color: #0f172a;
 }
@@ -54,7 +54,7 @@
 .stats-card__subtitle {
   margin: 0;
   font-size: 0.85rem;
-  color: #94a3b8;
+  color: #8a9ab7;
 }
 
 .stats-card--success .stats-card__icon {

--- a/src/css/project_dashboard.css
+++ b/src/css/project_dashboard.css
@@ -1,55 +1,61 @@
 .project-dashboard {
   min-height: 100vh;
-  padding: 2rem 2.5rem 2.5rem;
+  padding: 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  background: #f8fafc;
+  gap: 1.25rem;
+  background: radial-gradient(120% 120% at 0% 0%, #f5f7ff 0%, #eef2ff 45%, #ffffff 100%);
+}
+
+.project-dashboard > * {
+  width: min(1200px, 100%);
+  margin: 0 auto;
 }
 
 .project-dashboard__layout {
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: 1.5rem;
 }
 
 .project-dashboard__stats {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  align-items: stretch;
 }
 
 .project-dashboard__content {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
-  gap: 2rem;
+  grid-template-columns: minmax(0, 1.8fr) minmax(260px, 320px);
+  gap: 1.5rem;
   align-items: stretch;
 }
 
 .project-dashboard__main {
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
+  gap: 1.4rem;
 }
 
 .project-dashboard__grid {
   display: grid;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .project-dashboard__grid--two {
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .panel {
-  background: #ffffff;
-  border-radius: 24px;
-  padding: 1.75rem;
-  border: 1px solid rgba(226, 232, 240, 0.8);
-  box-shadow: 0 22px 40px rgba(15, 23, 42, 0.08);
+  background: linear-gradient(180deg, #ffffff 0%, #f7f9ff 92%);
+  border-radius: 18px;
+  padding: 1.4rem 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.06);
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.35rem;
 }
 
 .panel__header {
@@ -60,7 +66,7 @@
 
 .panel__header h2 {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 1.05rem;
   font-weight: 700;
   color: #0f172a;
 }
@@ -93,21 +99,23 @@
 
 @media (max-width: 1280px) {
   .project-dashboard {
-    padding: 1.75rem 1.75rem 2rem;
+    padding: 1.25rem;
+  }
+
+  .project-dashboard__stats {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   }
 
   .project-dashboard__content {
-    grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+    grid-template-columns: minmax(0, 1fr) minmax(240px, 300px);
+    gap: 1.25rem;
   }
 }
 
 @media (max-width: 1024px) {
-  .project-dashboard {
-    padding: 1.5rem 1.25rem 1.75rem;
-  }
-
   .project-dashboard__content {
     grid-template-columns: 1fr;
+    gap: 1.25rem;
   }
 
   .project-dashboard__grid--two {
@@ -116,12 +124,8 @@
 }
 
 @media (max-width: 640px) {
-  .project-dashboard {
-    padding: 1.25rem 1rem 1.5rem;
-  }
-
   .panel {
-    border-radius: 18px;
-    padding: 1.5rem;
+    border-radius: 16px;
+    padding: 1.25rem 1.3rem;
   }
 }


### PR DESCRIPTION
## Summary
- tighten the project dashboard layout spacing and constrain content width for a denser presentation
- refresh the header, panel, and stats card styles with lighter gradients and softer shadows
- adjust responsive breakpoints so cards and panels collapse earlier on smaller screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e660fa8eb8832db4a6c281e0fc9c23