### PR TITLE
Adjust dashboard width and pin assistant input

### DIFF
--- a/src/css/AssistantPanel.css
+++ b/src/css/AssistantPanel.css
@@ -1,4 +1,6 @@
 .assistant-panel {
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
   height: 100%;
 }
@@ -24,7 +26,8 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  max-height: 480px;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding-right: 0.5rem;
 }
@@ -126,6 +129,7 @@
   display: flex;
   gap: 0.75rem;
   align-items: center;
+  margin-top: auto;
 }
 
 .assistant-panel__input input {

--- a/src/css/project_dashboard.css
+++ b/src/css/project_dashboard.css
@@ -8,7 +8,7 @@
 }
 
 .project-dashboard > * {
-  width: min(1200px, 100%);
+  width: min(1600px, 100%);
   margin: 0 auto;
 }
 


### PR DESCRIPTION
## Summary
- expand the dashboard content container to a 1600px max width for wider layouts
- make the assistant panel a full-height column with the input form anchored to the bottom

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e66974e800832da1db9f41a8b42db2