### PR TITLE
Adjust sprint status colors and rearrange dashboard layout

### DIFF
--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -76,15 +76,19 @@ const toSafeInteger = (value: number): number => Math.max(0, Math.round(value));
 
 const inferSprintColor = (label: string): string => {
   const normalised = label.toLowerCase();
-  if (normalised.includes('done') || normalised.includes('complete')) {
-    return 'var(--color-success)';
+  if (/(done|complete|closed|finished|resolved)/.test(normalised)) {
+    return 'var(--color-status-done)';
   }
 
-  if (normalised.includes('todo') || normalised.includes('backlog') || normalised.includes('pending')) {
-    return 'var(--color-warning)';
+  if (/(progress|wip|active|doing)/.test(normalised)) {
+    return 'var(--color-status-in-progress)';
   }
 
-  return 'var(--color-info)';
+  if (/(todo|to-do|backlog|pending|queue|queued|not started|blocked|awaiting)/.test(normalised)) {
+    return 'var(--color-status-todo)';
+  }
+
+  return 'var(--color-status-other)';
 };
 
 type NormalisedStatusKey = 'done' | 'inProgress' | 'todo' | 'other';
@@ -989,9 +993,12 @@ const ProjectDashboard = (): JSX.Element => {
         </section>
         <section className="project-dashboard__content">
           <div className="project-dashboard__main">
+            <div className="project-dashboard__grid">
+              <TaskPriorityOverview priorities={priorityOverview} />
+            </div>
             <div className="project-dashboard__grid project-dashboard__grid--two">
               <SprintStatus segments={sprintSegments} />
-              <TaskPriorityOverview priorities={priorityOverview} />
+              <TeamProgress teams={teamProgress} />
             </div>
             <div className="project-dashboard__grid project-dashboard__grid--two">
               <IssuePanel
@@ -1009,7 +1016,6 @@ const ProjectDashboard = (): JSX.Element => {
                 tone="warning"
               />
             </div>
-            <TeamProgress teams={teamProgress} />
           </div>
           <AssistantPanel />
         </section>

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -12,6 +12,10 @@
   --color-warning: #fbbf24;
   --color-danger: #f87171;
   --color-info: #60a5fa;
+  --color-status-done: #10b981;
+  --color-status-in-progress: #f59e0b;
+  --color-status-todo: #6b7280;
+  --color-status-other: #6366f1;
 }
 
 *,


### PR DESCRIPTION
## Summary
- update sprint status color palette to use distinct dashboard-specific variables for done, in progress, and to-do states
- reposition dashboard sections so the task priority overview spans the row and sprint status sits beside team progress

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e67417c52c832dbc88c1a2acb7995d