### PR TITLE
Enhance sprint legend colors and redesign task priority chart

### DIFF
--- a/src/components/ProjectDashboard.tsx
+++ b/src/components/ProjectDashboard.tsx
@@ -74,6 +74,28 @@ const clampPercentage = (value: number): number => {
 
 const toSafeInteger = (value: number): number => Math.max(0, Math.round(value));
 
+const fallbackSegmentPalette = [
+  '#6366F1',
+  '#8B5CF6',
+  '#EC4899',
+  '#F97316',
+  '#14B8A6',
+  '#22D3EE',
+  '#F43F5E',
+  '#0EA5E9',
+  '#A3E635',
+  '#F59E0B',
+];
+
+const hashLabel = (label: string): number => {
+  let hash = 0;
+  for (let index = 0; index < label.length; index += 1) {
+    hash = (hash << 5) - hash + label.charCodeAt(index);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+};
+
 const inferSprintColor = (label: string): string => {
   const normalised = label.toLowerCase();
   if (/(done|complete|closed|finished|resolved)/.test(normalised)) {
@@ -88,7 +110,12 @@ const inferSprintColor = (label: string): string => {
     return 'var(--color-status-todo)';
   }
 
-  return 'var(--color-status-other)';
+  if (label.trim().length === 0) {
+    return fallbackSegmentPalette[0];
+  }
+
+  const paletteIndex = hashLabel(normalised) % fallbackSegmentPalette.length;
+  return fallbackSegmentPalette[paletteIndex];
 };
 
 type NormalisedStatusKey = 'done' | 'inProgress' | 'todo' | 'other';

--- a/src/css/TaskPriorityOverview.css
+++ b/src/css/TaskPriorityOverview.css
@@ -1,146 +1,112 @@
-.task-priority {
-  display: flex;
-  flex-wrap: wrap;
+.task-priority-overview {
   gap: 1.5rem;
-  align-items: flex-start;
 }
 
-.task-priority__chart {
+.task-priority-overview__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.task-priority-overview__legend {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.task-priority-overview__legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.task-priority-overview__chart {
   display: flex;
   gap: 1.5rem;
   align-items: flex-end;
+  min-height: 260px;
 }
 
-.task-priority__column {
+.task-priority-overview__column {
+  flex: 1;
+  min-width: 70px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.75rem;
-  position: relative;
-  transition: transform 0.3s ease;
+  gap: 0.65rem;
 }
 
-.task-priority__column.is-hovered {
-  transform: translateY(-6px);
-}
-
-.task-priority__bars {
+.task-priority-overview__track {
+  width: 100%;
+  max-width: 110px;
+  height: 220px;
+  padding: 12px 10px;
+  border-radius: 26px;
+  background: linear-gradient(180deg, rgba(148, 163, 184, 0.18) 0%, rgba(148, 163, 184, 0.08) 100%);
   display: flex;
   align-items: flex-end;
-  gap: 0.35rem;
-  height: 180px;
-  width: 70px;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.06) 0%, rgba(15, 23, 42, 0.02) 100%);
-  border-radius: 18px;
-  padding: 0.75rem 0.5rem;
-  transition: transform 0.25s ease;
-}
-
-.task-priority__bar {
-  flex: 1;
-  width: 16px;
-  border-radius: 999px;
-  position: relative;
+  justify-content: center;
   overflow: hidden;
-  height: 100%;
-  transform: scaleY(0) scaleX(1);
-  transform-origin: bottom;
-  will-change: transform;
-  transition: transform 0.7s cubic-bezier(0.33, 1, 0.68, 1),
-    box-shadow 0.3s ease,
-    filter 0.3s ease;
-  transition-delay: var(--bar-delay, 0s);
-  cursor: pointer;
 }
 
-.task-priority__bar.is-animated {
-  transform: scaleY(var(--bar-fill, 0)) scaleX(1);
+.task-priority-overview__stack {
+  width: 100%;
+  border-radius: 18px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  transition: height 0.55s cubic-bezier(0.33, 1, 0.68, 1);
 }
 
-.task-priority__bar.is-active {
-  transform: scaleY(var(--bar-fill, 0)) scaleX(1.08);
-  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.14);
-  filter: brightness(1.05);
+.task-priority-overview__segment {
+  width: 100%;
+  flex-shrink: 0;
+  transition: flex-basis 0.4s ease, background-color 0.3s ease;
 }
 
-.task-priority__bar:focus-visible {
-  outline: 2px solid rgba(59, 130, 246, 0.6);
-  outline-offset: 3px;
+.task-priority-overview__segment:first-child {
+  border-top-left-radius: 18px;
+  border-top-right-radius: 18px;
 }
 
-.task-priority__label {
+.task-priority-overview__segment:last-child {
+  border-bottom-left-radius: 18px;
+  border-bottom-right-radius: 18px;
+}
+
+.task-priority-overview__total {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #475569;
+  min-height: 1rem;
+}
+
+.task-priority-overview__label {
   margin: 0;
+  font-size: 0.95rem;
   font-weight: 600;
   color: #0f172a;
 }
 
-.task-priority__tooltip {
-  position: absolute;
-  top: -2.75rem;
-  background: rgba(15, 23, 42, 0.92);
-  color: #fff;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.15rem;
-  opacity: 0;
-  transform: translateY(-6px);
-  pointer-events: none;
-  transition: opacity 0.2s ease, transform 0.2s ease;
-  white-space: nowrap;
-}
+@media (max-width: 768px) {
+  .task-priority-overview__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 
-.task-priority__tooltip::after {
-  content: '';
-  position: absolute;
-  bottom: -6px;
-  width: 10px;
-  height: 10px;
-  background: rgba(15, 23, 42, 0.92);
-  transform: rotate(45deg);
-  border-radius: 2px;
-}
-
-.task-priority__tooltip-value {
-  font-size: 0.95rem;
-  font-weight: 600;
-}
-
-.task-priority__tooltip-label {
-  font-size: 0.65rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.task-priority__tooltip.is-visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-.task-priority__legend {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  color: #475569;
-  font-size: 0.95rem;
-}
-
-.task-priority__legend p {
-  margin: 0;
-  display: flex;
-  align-items: center;
+  .task-priority-overview__chart {
+    gap: 1.1rem;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .task-priority__bar {
-    transition: none;
-    transform: scaleY(var(--bar-fill, 0)) scaleX(1);
-  }
-
-  .task-priority__column,
-  .task-priority__tooltip {
+  .task-priority-overview__stack,
+  .task-priority-overview__segment {
     transition: none;
   }
 }


### PR DESCRIPTION
## Summary
- ensure sprint status segments fall back to unique deterministic colors so each legend entry is distinct
- rebuild the Task Priority Overview component with a stacked column layout and refreshed legend to match the provided design
- update task priority styles for the new layout and responsive behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e678144d58832d9ed0f5a9fac75b38